### PR TITLE
adding IN_MEMORY_CACHE_TIMEOUT and REDIS_CACHE_TIMEOUT to .env

### DIFF
--- a/.env
+++ b/.env
@@ -17,3 +17,8 @@ RABBITMQ_DEFAULT_VHOST=/
 # Celery settings
 CELERY_BROKER_URL=amqp://mazimi:maz1m1@rabbitmq:5672//
 CELERY_RESULT_BACKEND=redis://redis:6379/0
+
+
+# Caching timeouts : 
+IN_MEMORY_CACHE_TIMEOUT=300
+REDIS_CACHE_TIMEOUT=0


### PR DESCRIPTION
قبل تر از تسک #1 که با #2 مرج شد ، در ستینگ پروژه این اطلاعات از .env خونده میشدن ، اما به این دلیل که مقداری برای اون ها ست نشده بود ، به صورت دیفالت از ستینگ جنگو خونده میشدند . اما حالا این مقادیر توی .env هم ذخیره شدن . در زمان تغییر اون ها باید مجددا از داکر کامپوز بیلد گرفته بشه .